### PR TITLE
Add steps to detect loops in CFGs

### DIFF
--- a/joern/joernsteps/cfg.groovy
+++ b/joern/joernsteps/cfg.groovy
@@ -8,3 +8,24 @@ Gremlin.defineStep('toExitNode', [Vertex,Pipe], {
 	_().transform{ queryNodeIndex('functionId:' + it.functionId + " AND type:CFGExitNode ") }
 	.scatter()
 })
+
+/**
+   Search the CFG breadth-first so that we can keep track of all nodes we've visited in
+    the entire search rather than just along the current path (massive optimization for
+    high branching-factor CFGs, e.g. state machines).
+*/
+Object.metaClass._reachableCfgNodes = { curNodes, visited ->
+  nextNodes = curNodes._().out('FLOWS_TO').dedup.toSet() - visited
+  if (nextNodes.isEmpty()) { return visited }
+
+  visited.addAll(nextNodes)
+  return _reachableCfgNodes(nextNodes.toList(), visited)
+}
+
+Gremlin.defineStep('reachableCfgNodes', [Vertex, Pipe], {
+  _().transform { _reachableCfgNodes(it.statements().toList(), new HashSet())}.scatter()
+})
+
+Object.metaClass.isInLoop = { it ->
+  it._().reachableCfgNodes().toSet().contains(it)
+}

--- a/joern/joernsteps/cfg.groovy
+++ b/joern/joernsteps/cfg.groovy
@@ -15,7 +15,7 @@ Gremlin.defineStep('toExitNode', [Vertex,Pipe], {
     high branching-factor CFGs, e.g. state machines).
 */
 Object.metaClass._reachableCfgNodes = { curNodes, visited ->
-  nextNodes = curNodes._().out('FLOWS_TO').dedup.toSet() - visited
+  nextNodes = curNodes._().out('FLOWS_TO').toSet() - visited
   if (nextNodes.isEmpty()) { return visited }
 
   visited.addAll(nextNodes)

--- a/joern/joernsteps/cfg.groovy
+++ b/joern/joernsteps/cfg.groovy
@@ -27,5 +27,5 @@ Gremlin.defineStep('reachableCfgNodes', [Vertex, Pipe], {
 })
 
 Object.metaClass.isInLoop = { it ->
-  it._().reachableCfgNodes().toSet().contains(it)
+  it._().reachableCfgNodes().toSet().contains(it.statements().toList()[0])
 }


### PR DESCRIPTION
Looking for infinite loop DoS conditions, found this to be useful. Took multiple re-writes to make reachableCfgNodes fast, but now it runs in ~1s for a 2k LOC function with complex control flow.