### PR TITLE
fixes for adapting to py2neo-2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ traversals.
 Dependencies:
 --
 
-+ py2neo 1.6.1 (http://book.py2neo.org/en/latest/)
-+ py2neo-gremlin (https://github.com/fabsx00/py2neo-gremlin/)
++ py2neo 2.0.7 (http://py2neo.org/2.0/)
 
 
 ### Installation

--- a/joern/all.py
+++ b/joern/all.py
@@ -48,7 +48,7 @@ class JoernSteps:
         
     def runCypherQuery(self, cmd):
         """ Runs the specified cypher query on the graph database."""
-        return cypher.execute(self.graphDb, cmd)
+        return self.graphDb.cypher.execute(cmd)
 
     def getGraphDbURL(self):
         return self.graphDbURL

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,5 @@ setup(
                             'joernsteps/taintTracking/*.groovy',
                             'joernsteps/taintTracking/initGraphs/*.groovy'
                         ]},
-    install_requires = ['py2neo-gremlin == 0.1'],
-    dependency_links = ['https://github.com/fabsx00/py2neo-gremlin/tarball/master/#egg=py2neo-gremlin-0.1']
+    install_requires = ['py2neo >= 2.0.7']
 )


### PR DESCRIPTION
In commit ad48165192722fbf3eda83b2a5d40cb7144aeca6, python-joern was adapted to work with py2neo 2.0 instead of py2neo 1.6, and use the [gremlin plugin](http://py2neo.org/2.0/_modules/py2neo/ext/gremlin.html) bundled with py2neo 2.0 instead of the [fabsx00/py2neo-gremlin](https://github.com/fabsx00/py2neo-gremlin) plugin.

A few details were forgotten:
* There is no longer a dependency on the [fabsx00/py2neo-gremlin](https://github.com/fabsx00/py2neo-gremlin) plugin.
* As the py2neo API changed slightly, the runCypherQuery() relay function has to be adapted.

This PR fixes the above-mentioned problems.
